### PR TITLE
replace obsolete kwarg name

### DIFF
--- a/locking/views.py
+++ b/locking/views.py
@@ -70,7 +70,7 @@ def is_locked(request, app, model, id):
             "for_user": getattr(obj.locked_by, 'username', None),
             "applies": obj.lock_applies_to(request.user)
             })
-        return HttpResponse(response, mimetype='application/json')
+        return HttpResponse(response, content_type='application/json')
     except:
         return HttpResponse(status=200)
 @log


### PR DESCRIPTION
This bug combined with a bunch of open excepts in is_locked and lock causes multiple locks to happen.